### PR TITLE
fix: set a background color or apply the shadow to a more specific co…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,7 @@ export default function OutlinedText({
 
 const styles = StyleSheet.create({
   paragraph: {
+    backgroundColor: 'transparent',
     textShadowOffset: {
       width: 1,
       height: 1,


### PR DESCRIPTION
## Fix

- warning log View #315 of type RCTView has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this, or apply the shadow to a more specific component.